### PR TITLE
No data row col canadaian epay exception alex y

### DIFF
--- a/DomoAggregatorPlugin/DataReader.cs
+++ b/DomoAggregatorPlugin/DataReader.cs
@@ -185,9 +185,6 @@ namespace DomoAggregatorPlugin
                         rowData.Add(_currentConnection.DSN);
                         continue;
                     }
-                    //var dataProviderProperties = PropertyHelper.Deserialize<MyDataProviderProperties>(_callbackHost.GetProviderProperties());
-
-                    //LogEvent(LogMessageType.Progress,  _currentConnection.Reader.HasRows.ToString() +"yaedeadada");
 
                     if (!_currentConnection.Reader.HasRows)
                     {

--- a/DomoAggregatorPlugin/DataReader.cs
+++ b/DomoAggregatorPlugin/DataReader.cs
@@ -185,7 +185,14 @@ namespace DomoAggregatorPlugin
                         rowData.Add(_currentConnection.DSN);
                         continue;
                     }
+                    //var dataProviderProperties = PropertyHelper.Deserialize<MyDataProviderProperties>(_callbackHost.GetProviderProperties());
 
+                    //LogEvent(LogMessageType.Progress,  _currentConnection.Reader.HasRows.ToString() +"yaedeadada");
+
+                    if (!_currentConnection.Reader.HasRows)
+                    {
+                        return rowData;
+                    }
                     rowData.Add(_currentConnection.Reader[header]);
 
                     var key = $"{_currentConnection.DSN}:{header}";


### PR DESCRIPTION
Fixed the row / col exception on my local and I believe on Domo hopefully as well

Problem:
Two databases, Subscribera and Subscribertest. Say subscribera has data that matches the query in the job, subscribertest does not.
If we open subscriber a first, gets its data, then open subscribertest(which has no data) it will crash.
If we open subscribertest first, gets its data(none), then open subscribera, it will correctly output everything

With Brian's advice and some more investigating, I identified the problem to be if the LAST database opened does not have data called in the job / query, it will fail. Therefore I added a conditional that checks if there is necessary data, if there is not we will just return the null list in getrowdata, instead of calling the add function.